### PR TITLE
FIX: username with a dot (.) caused 404 error

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -99,9 +99,9 @@ after_initialize do
   Discourse::Application.routes.append do
     mount ::Follow::Engine, at: "follow"
     %w{users u}.each_with_index do |root_path, index|
-      get "#{root_path}/:username/follow" => "follow/follow#index"
-      get "#{root_path}/:username/follow/following" => "follow/follow#list"
-      get "#{root_path}/:username/follow/followers" => "follow/follow#list"
+      get "#{root_path}/:username/follow" => "follow/follow#index", constraints: { username: RouteFormat.username }
+      get "#{root_path}/:username/follow/following" => "follow/follow#list", constraints: { username: RouteFormat.username }
+      get "#{root_path}/:username/follow/followers" => "follow/follow#list", constraints: { username: RouteFormat.username }
     end
   end
 


### PR DESCRIPTION
Hello,

This PR fixes the error: username with a dot (.) caused 404.

Thanks